### PR TITLE
add authorisation for ws connections to remove need of passing accountId

### DIFF
--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/config/WebSocketConfig.kt
@@ -1,9 +1,7 @@
 package com.khomishchak.cryptopricingservice.config
 
-import com.google.gson.Gson
 import com.khomishchak.cryptopricingservice.service.ws.CryptoPriceWebsocketHandler
-import com.khomishchak.cryptopricingservice.service.ws.SessionMappingService
-import com.khomishchak.cryptopricingservice.service.ws.WebSocketService
+import com.khomishchak.cryptopricingservice.service.ws.message.WsMessageResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.socket.config.annotation.EnableWebSocket
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer
@@ -11,11 +9,9 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 
 @EnableWebSocket
 @Configuration
-class WebSocketConfig(private val sessionMappingService: SessionMappingService,
-                      private val webSocketService: WebSocketService,
-                      private val gson: Gson): WebSocketConfigurer {
+class WebSocketConfig(private val messageResolvers: List<WsMessageResolver>) : WebSocketConfigurer {
 
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
-        registry.addHandler(CryptoPriceWebsocketHandler(sessionMappingService, webSocketService, gson), "/crypto-pricing")
+        registry.addHandler(CryptoPriceWebsocketHandler(messageResolvers), "/crypto-pricing")
     }
 }

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/model/Urls.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/model/Urls.kt
@@ -1,0 +1,3 @@
+package com.khomishchak.cryptopricingservice.model
+
+const val AUTHENTICATE_TOKEN_URL = "http://localhost:8080/auth/token"

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/model/auth/JwtTokenValidationResult.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/model/auth/JwtTokenValidationResult.kt
@@ -1,0 +1,3 @@
+package com.khomishchak.cryptopricingservice.model.auth
+
+data class JwtTokenValidationResult(val userId: Long, val validated: Boolean)

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/SessionMappingService.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/SessionMappingService.kt
@@ -7,19 +7,28 @@ import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class SessionMappingService {
-    private val sessionMap = ConcurrentHashMap<Long, ConcurrentHashMap<String, WebSocketSession>>()
+
+    private val idToSessionMap = ConcurrentHashMap<Long, WebSocketSession>()
+    private val sessionToIdMap = ConcurrentHashMap<WebSocketSession, Long>()
 
     fun registerSession(session: WebSocketSession, accountId: Long) {
-        val sessions = sessionMap.computeIfAbsent(accountId) { ConcurrentHashMap() }
-        sessions[session.id] = session
+        idToSessionMap[accountId] = session
+        sessionToIdMap[session] = accountId
     }
 
-    // TODO: implement remove session functionality
-    fun removeSession(accountId: Long) = sessionMap.remove(accountId)
+    fun removeSession(accountId: Long) {
+        idToSessionMap[accountId].let {
+            idToSessionMap[accountId]
+            sessionToIdMap[it]
+        }
+    }
 
-    fun getSession(accountId: Long): WebSocketSession? = sessionMap[accountId]?.values?.firstOrNull();
+    fun getSession(accountId: Long) = idToSessionMap[accountId]
+    fun getUserId(session: WebSocketSession) = sessionToIdMap[session] ?: 0L
 
     fun sendMessageToSession(accountId: Long, message: String) =
             getSession(accountId)?.takeIf { it.isOpen
             }?.sendMessage(TextMessage(message))
+
+    fun sendMessageToSession(session: WebSocketSession, message: String) = session.sendMessage(TextMessage(message))
 }

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/WsMessageResolver.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/WsMessageResolver.kt
@@ -1,0 +1,11 @@
+package com.khomishchak.cryptopricingservice.service.ws.message
+
+import com.google.gson.JsonObject
+import org.springframework.web.socket.WebSocketSession
+
+interface WsMessageResolver {
+
+    fun getMessage(): String
+
+    fun process(messageJson: JsonObject, session: WebSocketSession)
+}

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/impl/AuthenticationMessageHandler.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/impl/AuthenticationMessageHandler.kt
@@ -1,0 +1,52 @@
+package com.khomishchak.cryptopricingservice.service.ws.message.impl
+
+import com.google.gson.JsonObject
+import com.khomishchak.cryptopricingservice.model.AUTHENTICATE_TOKEN_URL
+import com.khomishchak.cryptopricingservice.model.auth.JwtTokenValidationResult
+import com.khomishchak.cryptopricingservice.service.ws.SessionMappingService
+import com.khomishchak.cryptopricingservice.service.ws.message.WsMessageResolver
+import org.apache.kafka.common.protocol.types.Field.Str
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.socket.WebSocketSession
+
+@Service
+class AuthenticationMessageHandler(@Qualifier("pricingServiceRestTemplate") private val restTemplate: RestTemplate,
+                                   private val sessionMappingService: SessionMappingService) : WsMessageResolver {
+
+    override fun getMessage() = "authenticate"
+
+    override fun process(messageJson: JsonObject, session: WebSocketSession) =
+            validateJwtToken(messageJson["jwt"].asString).takeIf { it.validated }
+                ?.let { handleSuccessfulTokenValidation(it.userId, session) }
+                ?: handleFailedTokenValidation(session)
+
+    private fun handleSuccessfulTokenValidation(accountId: Long, session: WebSocketSession) {
+        sessionMappingService.registerSession(session, accountId)
+        sessionMappingService.sendMessageToSession(accountId, "authenticated account successfully")
+    }
+
+    private fun handleFailedTokenValidation(session: WebSocketSession) {
+        sessionMappingService.sendMessageToSession(session, "could not authenticated account")
+    }
+
+    private fun validateJwtToken(jwt: String): JwtTokenValidationResult =
+        HttpEntity(null, createAuthHeader(jwt)).let {
+            restTemplate.postForObject(
+                    AUTHENTICATE_TOKEN_URL,
+                    it,
+                    JwtTokenValidationResult::class.java
+            ) ?: JwtTokenValidationResult(0L, false)
+        }
+
+    private fun createAuthHeader(jwt: String): HttpHeaders =
+        HttpHeaders().apply {
+            set(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
+            contentType = MediaType.APPLICATION_JSON
+        }
+
+}

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/impl/SubscribeMarketMessageResolver.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/impl/SubscribeMarketMessageResolver.kt
@@ -1,0 +1,33 @@
+package com.khomishchak.cryptopricingservice.service.ws.message.impl
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.khomishchak.cryptopricingservice.model.integration.CryptoExchanger
+import com.khomishchak.cryptopricingservice.service.ws.SessionMappingService
+import com.khomishchak.cryptopricingservice.service.ws.WebSocketService
+import com.khomishchak.cryptopricingservice.service.ws.message.WsMessageResolver
+import org.springframework.stereotype.Service
+import org.springframework.web.socket.WebSocketSession
+
+@Service
+class SubscribeMarketMessageResolver(private val gson: Gson,
+                                     private val webSocketService: WebSocketService,
+                                     private val sessionMappingService: SessionMappingService) : WsMessageResolver {
+    override fun getMessage(): String = "subscribe_market"
+
+    override fun process(messageJson: JsonObject, session: WebSocketSession) {
+        val exchanger = CryptoExchanger.valueOf(messageJson["exchanger"].asString)
+        val tickersJsonArray = messageJson["tickers"].asJsonArray
+        val tickers: List<String> = tickersJsonArray.map { it.asString }
+
+        sessionMappingService.getUserId(session).takeIf { it != 0L }
+                ?.let {
+                    webSocketService.subscribe(it, exchanger, tickers)
+                    sendLatestPrices(it, exchanger, tickers)
+                }
+    }
+
+    private fun sendLatestPrices(accountId: Long, exchanger: CryptoExchanger, tickers: List<String>) =
+            gson.toJson(webSocketService.getLastPrices(accountId, exchanger, tickers))
+                    ?.let { sessionMappingService.sendMessageToSession(accountId, it) }
+}


### PR DESCRIPTION
added new ws method ("authenticate") that should be send right after the ws connection was established the change secures ws connection from 3rd party users as you need to provide proper jwt to be connected to the ws once connection is established and user was verified we create a key-value pair between userId and session, so there won't be any need to send userId separatly