### PR TITLE
added initialCurrency workflow for subscribe_market message

### DIFF
--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/model/MarkerSubscriptionDetails.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/model/MarkerSubscriptionDetails.kt
@@ -1,0 +1,11 @@
+package com.khomishchak.cryptopricingservice.model
+
+import com.khomishchak.cryptopricingservice.model.integration.CryptoExchanger
+
+
+
+data class MarkerSubscriptionDetails(val exchanger: CryptoExchanger,
+                                     val initialCurrency: String,
+                                     val tickers: List<String>) {
+    val allTickers : List<String> = listOf(initialCurrency) + tickers
+}

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/model/Urls.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/model/Urls.kt
@@ -2,3 +2,4 @@ package com.khomishchak.cryptopricingservice.model
 
 const val AUTHENTICATE_TOKEN_URL = "http://localhost:8080/auth/token"
 const val WHITEBIT_WEBSOCKET_CONNECT_URL = "wss://api.whitebit.com/ws";
+const val GET_USED_CURRENCIES_URL = "http://localhost:8080/exchangers/used-currencies"

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/model/integration/ChangedPriceMessage.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/model/integration/ChangedPriceMessage.kt
@@ -1,3 +1,3 @@
 package com.khomishchak.cryptopricingservice.model.integration
 
-data class ChangedPriceMessage(val ticker: String, val lastPrice: Double, val exchanger: CryptoExchanger)
+data class ChangedPriceMessage(var ticker: String, val lastPrice: Double, val exchanger: CryptoExchanger)

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/integration/IntegrationWebSocketService.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/integration/IntegrationWebSocketService.kt
@@ -1,5 +1,6 @@
 package com.khomishchak.cryptopricingservice.service.integration
 
+import com.khomishchak.cryptopricingservice.model.MarkerSubscriptionDetails
 import okhttp3.OkHttpClient
 import com.khomishchak.cryptopricingservice.model.integration.CryptoExchanger
 
@@ -7,7 +8,7 @@ import com.khomishchak.cryptopricingservice.model.integration.CryptoExchanger
 interface IntegrationWebSocketService {
     fun getCryptoExchangerType(): CryptoExchanger
     fun connect(client: OkHttpClient)
-    fun subscribe(accountId: Long, tickers: List<String>)
+    fun subscribe(accountId: Long, subscriptionDetails: MarkerSubscriptionDetails)
     fun getLastPrices(accountId: Long, tickers: List<String>): Map<String, Double>
     fun subscribeToAlreadyFollowedTickers(currencies: List<String>)
 }

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/WebSocketService.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/WebSocketService.kt
@@ -1,8 +1,9 @@
 package com.khomishchak.cryptopricingservice.service.ws
 
+import com.khomishchak.cryptopricingservice.model.MarkerSubscriptionDetails
 import com.khomishchak.cryptopricingservice.model.integration.CryptoExchanger
 
 interface WebSocketService {
-    fun subscribe(accountId: Long, exchanger: CryptoExchanger, tickers: List<String>)
+    fun subscribe(accountId: Long, subscriptionDetails: MarkerSubscriptionDetails)
     fun getLastPrices(accountId: Long, exchanger: CryptoExchanger, tickers: List<String>): Map<String, Double>
 }

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/WebSocketServiceImpl.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/WebSocketServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.khomishchak.cryptopricingservice.service.ws
 
 import com.google.gson.Gson
+import com.khomishchak.cryptopricingservice.model.GET_USED_CURRENCIES_URL
+import com.khomishchak.cryptopricingservice.model.MarkerSubscriptionDetails
 import com.khomishchak.cryptopricingservice.model.integration.CryptoExchanger
 import com.khomishchak.cryptopricingservice.model.internall.exchanger.UsedToken
 import com.khomishchak.cryptopricingservice.model.internall.exchanger.UsedTokens
@@ -12,7 +14,6 @@ import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.client.getForObject
 
-const val GET_USED_CURRENCIES_URL = "http://localhost:8080/exchangers/used-currencies"
 @Service
 class WebSocketServiceImpl (private val integrationWebSocketConnectors: List<IntegrationWebSocketService>,
                             @Qualifier("pricingServiceRestTemplate") private val restTemplate: RestTemplate)
@@ -28,8 +29,8 @@ class WebSocketServiceImpl (private val integrationWebSocketConnectors: List<Int
         integrationWebSocketConnectors.forEach { it.connect(client) }
     }
 
-    override fun subscribe(accountId: Long, exchanger: CryptoExchanger, tickers: List<String>) =
-            websocketIntegrations[exchanger]?.subscribe(accountId, tickers) ?: Unit
+    override fun subscribe(accountId: Long, subscriptionDetails: MarkerSubscriptionDetails) =
+            websocketIntegrations[subscriptionDetails.exchanger]?.subscribe(accountId, subscriptionDetails) ?: Unit
 
     override fun getLastPrices(accountId: Long, exchanger: CryptoExchanger, tickers: List<String>) =
             websocketIntegrations[exchanger]?.getLastPrices(accountId, tickers) ?: emptyMap();

--- a/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/impl/SubscribeMarketMessageResolver.kt
+++ b/src/main/kotlin/com/khomishchak/cryptopricingservice/service/ws/message/impl/SubscribeMarketMessageResolver.kt
@@ -2,6 +2,7 @@ package com.khomishchak.cryptopricingservice.service.ws.message.impl
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.khomishchak.cryptopricingservice.model.MarkerSubscriptionDetails
 import com.khomishchak.cryptopricingservice.model.integration.CryptoExchanger
 import com.khomishchak.cryptopricingservice.service.ws.SessionMappingService
 import com.khomishchak.cryptopricingservice.service.ws.WebSocketService
@@ -9,23 +10,30 @@ import com.khomishchak.cryptopricingservice.service.ws.message.WsMessageResolver
 import org.springframework.stereotype.Service
 import org.springframework.web.socket.WebSocketSession
 
+fun JsonObject.mapToMarkerSubscriptionDetails() =
+        MarkerSubscriptionDetails(
+                CryptoExchanger.valueOf(this["exchanger"].asString),
+                this["initialCurrency"].asString,
+                this["tickers"].asJsonArray.map { ticker -> ticker.asString }
+        )
+
 @Service
 class SubscribeMarketMessageResolver(private val gson: Gson,
                                      private val webSocketService: WebSocketService,
                                      private val sessionMappingService: SessionMappingService) : WsMessageResolver {
     override fun getMessage(): String = "subscribe_market"
 
-    override fun process(messageJson: JsonObject, session: WebSocketSession) {
-        val exchanger = CryptoExchanger.valueOf(messageJson["exchanger"].asString)
-        val tickersJsonArray = messageJson["tickers"].asJsonArray
-        val tickers: List<String> = tickersJsonArray.map { it.asString }
 
+    override fun process(messageJson: JsonObject, session: WebSocketSession): Unit =
+            messageJson.mapToMarkerSubscriptionDetails().let { handleMarketSubscriptionRequest(session, it) }
+
+
+    private fun handleMarketSubscriptionRequest(session: WebSocketSession, markerSubscriptionDetails: MarkerSubscriptionDetails) =
         sessionMappingService.getUserId(session).takeIf { it != 0L }
                 ?.let {
-                    webSocketService.subscribe(it, exchanger, tickers)
-                    sendLatestPrices(it, exchanger, tickers)
+                    webSocketService.subscribe(it, markerSubscriptionDetails)
+                    sendLatestPrices(it, markerSubscriptionDetails.exchanger, markerSubscriptionDetails.allTickers)
                 }
-    }
 
     private fun sendLatestPrices(accountId: Long, exchanger: CryptoExchanger, tickers: List<String>) =
             gson.toJson(webSocketService.getLastPrices(accountId, exchanger, tickers))


### PR DESCRIPTION
initialCurrency will be the currency used by user (for example user want to know price of ETH in PLNs, PLN is intialCurrency) it will be saved in separate cache to handle it as initialCurrency, it will be marked as INITIAL_CURRENCY for FE to know when it is updated it will be sent in initial response with all the currencies from tickers list